### PR TITLE
fix can not perform play in release mode

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.21'
+    ext.kotlin_version = '1.3.61'
     ext.coroutine_version = '1.0.0'
     repositories {
         google()
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri May 10 21:20:21 CST 2019
+#Sun Dec 22 01:00:46 CST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/lib/component/player/lryic.dart
+++ b/lib/component/player/lryic.dart
@@ -58,7 +58,7 @@ class PlayingLyric extends Model {
     if (lyric != null && lyric.isNotEmpty) {
       _lyricContent = LyricContent.from(lyric);
     }
-    if (_lyricContent.size == 0) {
+    if (_lyricContent?.size == 0) {
       _lyricContent = null;
     }
     if (_lyricContent == null) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -35,6 +35,7 @@ void main() {
 
 /// The entry of dart background service
 /// NOTE: this method will be invoked by native (Android/iOS)
+@pragma('vm:entry-point') // avoid Tree Shaking
 void playerBackgroundService() {
   WidgetsFlutterBinding.ensureInitialized();
   // 获取播放地址需要使用云音乐 API, 所以需要为此 isolate 初始化一个 repository.


### PR DESCRIPTION
The background entry point has been removed due to Dart Tree Sharking.

more details see : https://github.com/flutter/flutter/wiki/Experimental:-Launch-Flutter-with-non-main-entrypoint#avoid-tree-shaking-in-release

fix #90 fix #88 